### PR TITLE
Fix error-out and firewall

### DIFF
--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -40,22 +40,16 @@ method = Fake
 EOF"
 
 if ! systemctl is-active postgresql.service &> /dev/null; then
-#ret=$?
-#if [[ $ret -ne 0 ]]; then
   sudo postgresql-setup --initdb
   sudo systemctl enable --now postgresql
 fi
 
 if ! systemctl is-active sshd.service &> /dev/null; then
-#ret=$?
-#if [[ $ret -ne 0 ]]; then
   sudo systemctl start sshd
   sudo systemctl enable sshd
 fi
 
-systemctl is-active httpd.service &> /dev/null
-ret=$?
-if [[ $ret -ne 0 ]]; then
+if ! systemctl is-active httpd.service &> /dev/null; then
   sudo systemctl enable --now httpd
   sudo systemctl enable --now openqa-gru
   sudo systemctl enable --now openqa-scheduler
@@ -66,8 +60,8 @@ if [[ $ret -ne 0 ]]; then
   sudo systemctl restart httpd
 fi
 
-#sudo firewall-cmd --add-port=80/tcp
-#sudo firewall-cmd --runtime-to-permanent
+sudo firewall-cmd --permanent --add-service=http
+sudo firewall-cmd --reload
 
 if sudo grep -q foo /etc/openqa/client.conf; then
   sudo bash -c "cat >/etc/openqa/client.conf <<'EOF'


### PR DESCRIPTION
# Description

Fix spot where script errors out because of the `-e` at the top of the script. Also brings the if statement in line with the others.

Fix http firewall rules. Needed to let http traffic through.

# How Has This Been Tested?

Run against a fresh install of Fedora server.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
