### PR TITLE
Curl v Wget

### DIFF
--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -14,10 +14,10 @@ fi
 sudo mkdir -p /var/lib/openqa/share/factory/iso
 if [[ ! -f /var/lib/openqa/share/factory/iso/CHECKSUM ]]; then
   cd /var/lib/openqa/share/factory/iso
-  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-boot.iso
-  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-minimal.iso
-  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-dvd1.iso
-  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/CHECKSUM
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-boot.iso
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-minimal.iso
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-dvd1.iso
+  sudo curl -C - -O download.rockylinux.org/pub/rocky/8/isos/x86_64/CHECKSUM
   shasum -a 256 --ignore-missing -c CHECKSUM
 fi
 

--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -14,10 +14,10 @@ fi
 sudo mkdir -p /var/lib/openqa/share/factory/iso
 if [[ ! -f /var/lib/openqa/share/factory/iso/CHECKSUM ]]; then
   cd /var/lib/openqa/share/factory/iso
-  sudo wget -c download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-boot.iso
-  sudo wget -c download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-minimal.iso
-  sudo wget -c download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-dvd1.iso
-  sudo wget -c download.rockylinux.org/pub/rocky/8/isos/x86_64/CHECKSUM
+  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-boot.iso
+  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-minimal.iso
+  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.4-x86_64-dvd1.iso
+  sudo curl -O download.rockylinux.org/pub/rocky/8/isos/x86_64/CHECKSUM
   shasum -a 256 --ignore-missing -c CHECKSUM
 fi
 


### PR DESCRIPTION
# Description

Wget isn't installed in the minimal version of Fedora and the installation script never specifies it. Curl is installed by default.

# How Has This Been Tested?

Ran on dev system.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
