### PR TITLE
fifloader fix; worker start fix

### DIFF
--- a/install-openqa-post-rocky.sh
+++ b/install-openqa-post-rocky.sh
@@ -30,9 +30,7 @@ sudo openqa-cli api -X POST isos \
   VERSION=8 \
   GRUB="ip=dhcp bootdev=52:54:00:12:34:56 inst.waitfornet=300"
 
-
-systemctl is-active openqa-worker@1 &> /dev/null
-if [[ $? -eq 1 ]]; then
+if ! systemctl is-active openqa-worker@1 &> /dev/null; then
   sudo systemctl enable --now openqa-worker@1
 fi
 

--- a/install-openqa.sh
+++ b/install-openqa.sh
@@ -65,7 +65,6 @@ sudo firewall-cmd --reload
 
 if sudo grep -q foo /etc/openqa/client.conf; then
   sudo bash -c "cat >/etc/openqa/client.conf <<'EOF'
->>>>>>> Stashed changes
 [localhost]
 key = 1234567890ABCDEF
 secret = 1234567890ABCDEF


### PR DESCRIPTION
# Description

There are two issues being addressed.
The first is an extra line in the config file that would break fifloader in odd and interesting ways. Took me a while to realize it wasn't fifloader that was broke. :-)

The second is fixing the systemctl check for the openqa-worker which previously errored out the script.

# How Has This Been Tested?

Local testing.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
